### PR TITLE
fix container width, padding on smaller viewports

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -86,7 +86,7 @@ const Content = () => {
 
 export default function Home() {
   return (
-    <main className="flex flex-col p-24">
+    <main className="flex flex-col max-w-5xl p-10 md:py-24 mx-auto">
       <div>
         <h1 className="text-2xl font-bold">70Check</h1>
       </div>


### PR DESCRIPTION
Container width on mobile is a bit hard to read: 
<img width="413" alt="image" src="https://github.com/t3dotgg/70check/assets/30325728/cc5dd6cc-7f85-4b9b-9777-1a85fef9a31c">

This adds a maximum container width for desktop + adds some sensible padding on mobile viewports.

<img width="417" alt="image" src="https://github.com/t3dotgg/70check/assets/30325728/4d8129e7-8b34-4906-aa57-52e786b76a98">